### PR TITLE
Template sanity checking

### DIFF
--- a/lib/sugar/templates.ex
+++ b/lib/sugar/templates.ex
@@ -46,8 +46,12 @@ defmodule Sugar.Templates do
     html
   end
   def render(key, assigns) do
-    template = key
-      |> Atom.to_string if Kernel.is_atom(key)
+    if Kernel.is_atom(key) do
+      stringified_key = Atom.to_string(key)
+    else
+      stringified_key = key
+    end
+    template = stringified_key
       |> String.replace("/", "_")
       |> get_template
     { :ok, html } = template.engine.render template, assigns

--- a/lib/sugar/templates.ex
+++ b/lib/sugar/templates.ex
@@ -48,7 +48,7 @@ defmodule Sugar.Templates do
   def render(key, assigns) do
     # Sanity check.  If we get an error tuple instead of a key, don't let it get
     # shoved into String.replace/4 or confusingly-bad things will happen.
-    if key == {:error, :notfound}, do
+    if key == {:error, :notfound} do
       raise "Template not found"
     end
     template = key

--- a/lib/sugar/templates.ex
+++ b/lib/sugar/templates.ex
@@ -46,6 +46,7 @@ defmodule Sugar.Templates do
     html
   end
   def render(key, assigns) do
+    if key == {:error, :notfound}, do: raise "NOT FOUND"  # Test; please ignore
     if Kernel.is_atom(key) do
       stringified_key = Atom.to_string(key)
     else

--- a/lib/sugar/templates.ex
+++ b/lib/sugar/templates.ex
@@ -46,13 +46,12 @@ defmodule Sugar.Templates do
     html
   end
   def render(key, assigns) do
-    if key == {:error, :notfound}, do: raise "NOT FOUND"  # Test; please ignore
-    if Kernel.is_atom(key) do
-      stringified_key = Atom.to_string(key)
-    else
-      stringified_key = key
+    # Sanity check.  If we get an error tuple instead of a key, don't let it get
+    # shoved into String.replace/4 or confusingly-bad things will happen.
+    if key == {:error, :notfound}, do
+      raise "Template not found"
     end
-    template = stringified_key
+    template = key
       |> String.replace("/", "_")
       |> get_template
     { :ok, html } = template.engine.render template, assigns

--- a/lib/sugar/templates.ex
+++ b/lib/sugar/templates.ex
@@ -47,6 +47,7 @@ defmodule Sugar.Templates do
   end
   def render(key, assigns) do
     template = key
+      |> Atom.to_string if Kernel.is_atom(key)
       |> String.replace("/", "_")
       |> get_template
     { :ok, html } = template.engine.render template, assigns

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Templates.Mixfile do
 
   def project do
     [ app: :templates,
-      version: "0.0.5",
+      version: "0.0.6",
       elixir: "~> 1.0.0",
       name: "Templates",
       deps: deps,


### PR DESCRIPTION
Now, instead of throwing obscure ArgumentErrors (or, more precisely, feeding `String.replace/4` garbage that *causes* said ArgumentErrors), `Sugar.Templates.render/2` will now detect whether or not it received a `{:error, :notfound}` tuple; if it does receive such a tuple, it will `raise "Template not found"`, thus actually indicating that a template can't be found.